### PR TITLE
Fix asynchronous plant creation

### DIFF
--- a/src/app/add-plant/page.tsx
+++ b/src/app/add-plant/page.tsx
@@ -56,7 +56,7 @@ export default function AddPlantPage() {
     haptic.mediumImpact();
 
     try {
-      addPlant({
+      await addPlant({
         name: formData.name.trim(),
         species: selectedType,
         wateringFrequency: formData.wateringFrequency,


### PR DESCRIPTION
## Summary
- await the async `addPlant` call when submitting the add-plant form

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c9a35888325b7714393ce4fdfa2