### PR TITLE
Update README for Next.js context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plant Tracker 🌱
 
-A beautiful React Native app for tracking your plants with a cute Tamagotchi-style interface. Built with Expo, TypeScript, and NativeWind.
+A sleek **Next.js** web application for tracking your plants with a cute Tamagotchi-style interface. Built with TypeScript and Tailwind CSS.
 
 ## Features
 
@@ -12,14 +12,13 @@ A beautiful React Native app for tracking your plants with a cute Tamagotchi-sty
 
 ## Tech Stack
 
-- **Expo SDK 50+** with EAS build profile
-- **React Native 0.73+** with TypeScript strict mode
-- **React Navigation v6** (Drawer + Bottom Tabs)
-- **NativeWind** for utility-first styling
-- **React Native SVG** + **Moti** for animations
-- **Expo Vector Icons** (Ionicons)
+- **Next.js 14** with React 18
+- **TypeScript** with strict mode
+- **Tailwind CSS** for utility-first styling
+- **Radix UI** for accessible components
+- **Framer Motion** for animations
 - **React Hook Form** for form management
-- **AsyncStorage** for local persistence
+- **Zustand** for state management
 - **Supabase** (ready for backend integration)
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- update intro paragraph to mention Next.js web app
- swap React Native/Expo tech stack for Next.js stack

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683f70c597108325b453b0489f02e737