### PR TITLE
Add Jest and tests for plant store

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  testMatch: ['**/__tests__/**/*.(test|spec).ts?(x)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "precommit": "npm run lint && npm run type-check",
     "preview": "npm run build && npm run start",
     "clean": "rm -rf .next out",
-    "postbuild": "echo 'Build completed successfully!'"
+    "postbuild": "echo 'Build completed successfully!'",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.5",
@@ -65,7 +66,12 @@
     "lighthouse": "^11.4.0",
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "^0.5.9",
-    "storybook": "^7.6.6"
+    "storybook": "^7.6.6",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.0",
+    "jest-environment-jsdom": "^29.7.0"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/src/lib/__tests__/plant-store.test.ts
+++ b/src/lib/__tests__/plant-store.test.ts
@@ -1,0 +1,56 @@
+import { addDays, subDays, format } from 'date-fns';
+import { calculateNextWatering, getPlantStatus } from '../plant-store';
+
+describe('calculateNextWatering', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns "Tomorrow" when frequency is 1', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-04-01'));
+    expect(calculateNextWatering(1)).toBe('Tomorrow');
+  });
+
+  test('returns in x days when frequency is less than or equal to 7', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-04-01'));
+    expect(calculateNextWatering(5)).toBe('in 5 days');
+  });
+
+  test('returns formatted date when frequency is greater than 7', () => {
+    const now = new Date('2024-04-01');
+    jest.useFakeTimers().setSystemTime(now);
+    const expected = format(addDays(now, 10), 'MMM dd');
+    expect(calculateNextWatering(10)).toBe(expected);
+  });
+});
+
+describe('getPlantStatus', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns healthy when lastWatered is undefined', () => {
+    expect(getPlantStatus('', 3)).toBe('healthy');
+  });
+
+  test('returns needs_water when past frequency', () => {
+    const now = new Date('2024-04-10');
+    jest.useFakeTimers().setSystemTime(now);
+    const lastWatered = subDays(now, 3).toISOString();
+    expect(getPlantStatus(lastWatered, 3)).toBe('needs_water');
+  });
+
+  test('returns overdue when significantly past frequency', () => {
+    const now = new Date('2024-04-10');
+    jest.useFakeTimers().setSystemTime(now);
+    const lastWatered = subDays(now, 5).toISOString();
+    expect(getPlantStatus(lastWatered, 2)).toBe('overdue');
+  });
+
+  test('returns healthy when watered recently', () => {
+    const now = new Date('2024-04-10');
+    jest.useFakeTimers().setSystemTime(now);
+    const lastWatered = subDays(now, 1).toISOString();
+    expect(getPlantStatus(lastWatered, 3)).toBe('healthy');
+  });
+});

--- a/src/lib/plant-store.tsx
+++ b/src/lib/plant-store.tsx
@@ -370,7 +370,9 @@ export function PlantProvider({ children }: { children: ReactNode }) {
 export function usePlants() {
   const store = usePlantStore();
   const context = useContext(PlantContext);
-  
+
   // Return context if available, otherwise fallback to direct store access
   return context || store;
-} 
+}
+
+export { calculateNextWatering, getPlantStatus };


### PR DESCRIPTION
## Summary
- add Jest config with jsdom setup
- export helpers from `plant-store`
- add unit tests for `calculateNextWatering` and `getPlantStatus`
- wire up `npm test` script
- include testing library dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f70feec4083258e6cd7b77eb3620b