### PR TITLE
Fix mobile scroll issues

### DIFF
--- a/src/components/SwipeFilters.tsx
+++ b/src/components/SwipeFilters.tsx
@@ -64,8 +64,9 @@ export function SwipeFilters({ filters, activeFilter, onFilterChange }: SwipeFil
         onDrag={handleDrag}
         onDragEnd={handleDragEnd}
         animate={controls}
-        className="flex touch-pan-x"
+        className="flex"
         style={{
+          touchAction: 'pan-y',
           x: dragOffset,
         }}
       >

--- a/src/components/SwipeableCard.tsx
+++ b/src/components/SwipeableCard.tsx
@@ -122,6 +122,7 @@ export function SwipeableCard({
         drag="x"
         dragConstraints={{ left: -200, right: 200 }}
         dragElastic={0.1}
+        style={{ touchAction: 'pan-y' }}
         animate={controls}
         onDrag={(event, info) => {
           try {

--- a/src/components/SwipeableListItem.tsx
+++ b/src/components/SwipeableListItem.tsx
@@ -131,6 +131,7 @@ export function SwipeableListItem({
         drag="x"
         dragConstraints={{ left: -120, right: 120 }}
         dragElastic={0.1}
+        style={{ touchAction: 'pan-y' }}
         whileTap={{ scale: 0.98 }}
       >
         {/* Water Animation Overlay */}


### PR DESCRIPTION
## Summary
- allow vertical scroll on swipeable cards, list items, and filters
- set `touchAction: 'pan-y'` on draggable elements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405d51e8a08325861f79b2c3b9b331