### PR TITLE
Fix plant store clearing on logout

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/utils/supabase';
+import { usePlantStore } from '@/lib/plant-store';
 
 interface AuthContextType {
   user: User | null;
@@ -84,6 +85,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signOut = async () => {
     await supabase.auth.signOut();
+    // Clear local plant data when user signs out
+    usePlantStore.getState().clearPlants();
   };
 
   const value = {

--- a/src/lib/plant-store.tsx
+++ b/src/lib/plant-store.tsx
@@ -43,6 +43,7 @@ interface PlantStore {
   refreshPlants: () => Promise<void>;
   clearError: () => void;
   clearRecentlyWatered: () => void;
+  clearPlants: () => void;
   getPlantById: (id: string) => Plant | undefined;
   getHealthyPlants: () => Plant[];
   getPlantsNeedingWater: () => Plant[];
@@ -409,6 +410,10 @@ export const usePlantStore = create<PlantStore>()(
 
       clearRecentlyWatered: () => {
         set({ recentlyWateredPlant: null });
+      },
+
+      clearPlants: () => {
+        set({ plants: [], recentlyWateredPlant: null });
       },
 
       getPlantById: (id) => {


### PR DESCRIPTION
## Summary
- clear plant list when signing out so data isn't shown when logged out
- expose new `clearPlants` store action and invoke it in `signOut`

## Testing
- `npm test` *(fails: jest not installed)*
- `npm run type-check` *(fails: dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a4b24db483258b671d197762d985