### PR TITLE
perf: optimize Planter for Vercel deployment and production runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,31 +54,25 @@ npm run type-check
 
 ## 📦 Deployment
 
-### Netlify (Recommended)
-
-The project is configured for Netlify deployment with:
-- Automatic builds from Git
-- Edge functions support
-- PWA optimization
-- Performance headers
-
 ### Vercel
 
-This repository is now configured for both Netlify and Vercel:
+This repository is optimized for **Vercel deployment**:
 
-- **Netlify build command**: `npm run build:netlify`
 - **Vercel build command**: `npm run build:vercel`
 - **Static export build** (for Capacitor/offline bundles): `npm run build:static`
 
 `next.config.js` automatically switches behavior using `NEXT_STATIC_EXPORT=true` only when static export is explicitly requested.
 
+For a complete setup walkthrough, see `docs/vercel-deployment.md`.
+
 ### Environment Variables for Production
 
-Set these in your deployment platform:
+Set these in your Vercel project:
 
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-key
+NEXT_PUBLIC_APP_URL=https://your-project-name.vercel.app
 NEXT_TELEMETRY_DISABLED=1
 ```
 
@@ -92,7 +86,7 @@ NEXT_TELEMETRY_DISABLED=1
 - **Storage**: IndexedDB/LocalStorage
 - **Animations**: Framer Motion
 - **Testing**: Jest + React Testing Library
-- **Deployment**: Netlify
+- **Deployment**: Vercel
 
 ## 📁 Project Structure
 

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -1,0 +1,48 @@
+# Vercel Deployment Guide
+
+This project is configured for Vercel-first deployment with Next.js App Router.
+
+## 1) Vercel project settings
+
+- Framework Preset: **Next.js**
+- Build Command: `npm run build:vercel`
+- Install Command: `npm ci`
+- Output Directory: leave default (`.next`)
+
+## 2) Required environment variables
+
+Set these in **Vercel → Project → Settings → Environment Variables**:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_APP_URL` (set to your production URL, e.g. `https://your-project.vercel.app`)
+- `NEXT_TELEMETRY_DISABLED=1`
+
+## 3) Performance and caching behavior
+
+The app is configured to:
+
+- Serve immutable cache headers for static assets.
+- Keep service worker requests revalidated.
+- Use AVIF/WebP formats via Next.js image optimization.
+- Enable production compression.
+
+## 4) Pre-deploy checks
+
+Run locally before deploying:
+
+```bash
+npm run lint
+npm run type-check
+npm run build:vercel
+```
+
+## 5) Optional static export mode
+
+If you are generating an export bundle for Capacitor/offline builds:
+
+```bash
+NEXT_STATIC_EXPORT=true npm run build:static
+```
+
+This is separate from the standard Vercel runtime build.

--- a/next.config.js
+++ b/next.config.js
@@ -3,10 +3,19 @@ const isStaticExport = process.env.NEXT_STATIC_EXPORT === 'true';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   ...(isStaticExport ? { output: 'export', assetPrefix: './' } : {}),
-  trailingSlash: true,
+  trailingSlash: isStaticExport,
   poweredByHeader: false,
+  reactStrictMode: true,
+  compress: true,
   images: {
     unoptimized: isStaticExport,
+    formats: ['image/avif', 'image/webp'],
+  },
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production' ? { exclude: ['error', 'warn'] } : false,
+  },
+  experimental: {
+    optimizePackageImports: ['date-fns', 'framer-motion', '@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu'],
   },
   async headers() {
     return [
@@ -25,7 +34,7 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: blob:",
               "font-src 'self' data:",
-              "connect-src 'self' https://*.supabase.co https://*.netlify.app",
+              "connect-src 'self' https://*.supabase.co",
               "frame-ancestors 'none'",
               "base-uri 'self'",
               "form-action 'self'",
@@ -33,8 +42,20 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/sw.js',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=0, must-revalidate' },
+        ],
+      },
+      {
+        source: '/(.*).(js|css|woff2|svg|png|jpg|jpeg|webp|avif)',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+        ],
+      },
     ];
   },
 };
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,13 @@ import { Providers } from './providers';
 import { Toaster } from '@/components/ui/toast';
 import { BottomNavigation } from '@/components/BottomNavigation';
 import { PageTransition } from '@/components/PageTransition';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 
-export const metadata = {
-  metadataBase: new URL('https://simmys-plant-diary.netlify.app'),
+const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://planter.vercel.app';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(appUrl),
   title: 'Planter',
   description: 'A beautiful plant care app with a Tamagotchi-style companion to help you nurture your green friends.',
   keywords: 'plants, care, tracking, watering, garden, tamagotchi, plant diary, garden app, simmy',
@@ -19,7 +22,7 @@ export const metadata = {
     description: 'A beautiful plant care app with a Tamagotchi-style companion.',
     type: 'website',
     locale: 'en_US',
-    url: 'https://simmys-plant-diary.netlify.app',
+    url: appUrl,
     siteName: 'Planter',
     images: [
       {
@@ -48,7 +51,7 @@ export const metadata = {
   }
 };
 
-export const viewport = {
+export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
@@ -67,32 +70,12 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover, user-scalable=no" />
-        <meta name="theme-color" content="#10B981" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Planter" />
-        
-        {/* Preconnect to external domains for performance */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link rel="preconnect" href="https://cdn.jsdelivr.net" />
-        <link rel="preconnect" href="https://analytics.netlify.com" />
-        
-        {/* Security headers */}
-        <meta httpEquiv="X-Content-Type-Options" content="nosniff" />
-        <meta httpEquiv="X-Frame-Options" content="DENY" />
-        <meta httpEquiv="X-XSS-Protection" content="1; mode=block" />
-        <meta
-          httpEquiv="Content-Security-Policy"
-          content="default-src 'self'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co https://*.netlify.app; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
-        />
-        
-        {/* Favicon and app icons */}
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-        <link rel="manifest" href="/manifest.json" />
       </head>
       <body className="font-sans antialiased bg-background text-foreground transition-colors duration-300 min-h-dvh overflow-x-hidden">
         <div className="min-h-dvh bg-background">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import Link from 'next/link';
+import dynamic from 'next/dynamic';
 import { TamagotchiBlob } from '@/components/TamagotchiBlob';
-import { AuthModal } from '@/components/AuthModal';
 import { usePlants } from '@/lib/plant-store';
 import { useAuth } from '@/contexts/AuthContext';
 import { useHapticFeedback } from '@/hooks/useMobileGestures';
 import { useRouter } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { isSupabaseConfigured } from '@/utils/supabase';
-import { FadeIn, SlideUp, StaggerContainer as StaggeredChildren, ScaleIn } from '@/components/AnimationReplacements';
+import { FadeIn, SlideUp, ScaleIn } from '@/components/AnimationReplacements';
+
+const AuthModal = dynamic(
+  () => import('@/components/AuthModal').then((mod) => mod.AuthModal),
+  { ssr: false },
+);
 
 export default function HomePage() {
   const { plants, triggerManualSync, loading, hasHydrated, syncQueueCount } = usePlants();
@@ -25,10 +29,34 @@ export default function HomePage() {
     setIsClientReady(true);
   }, []);
 
-  const healthyPlants = plants.filter(p => p.status === 'healthy').length;
-  const plantsNeedingWater = plants.filter(p => p.status === 'needs_water' || p.status === 'overdue').length;
+  const healthyPlants = useMemo(
+    () => plants.filter((p) => p.status === 'healthy').length,
+    [plants],
+  );
+  const plantsNeedingWater = useMemo(
+    () => plants.filter((p) => p.status === 'needs_water' || p.status === 'overdue').length,
+    [plants],
+  );
   const isDbConfigured = isSupabaseConfigured();
   const isOffline = typeof navigator !== 'undefined' ? !navigator.onLine : false;
+
+  const handleSignOut = useCallback(async () => {
+    haptic.mediumImpact();
+    await signOut();
+  }, [haptic, signOut]);
+
+  const handleSync = useCallback(async () => {
+    if (!isDbConfigured || !user) return;
+    
+    haptic.mediumImpact();
+    try {
+      await triggerManualSync();
+      haptic.success();
+    } catch (error) {
+      console.error('Sync failed:', error);
+      haptic.error();
+    }
+  }, [haptic, isDbConfigured, triggerManualSync, user]);
 
   // Show simple loading only on initial hydration
   if (!isClientReady || (!hasHydrated && loading)) {
@@ -41,24 +69,6 @@ export default function HomePage() {
       </div>
     );
   }
-
-  const handleSignOut = async () => {
-    haptic.mediumImpact();
-    await signOut();
-  };
-
-  const handleSync = async () => {
-    if (!isDbConfigured || !user) return;
-    
-    haptic.mediumImpact();
-    try {
-      await triggerManualSync();
-      haptic.success();
-    } catch (error) {
-      console.error('Sync failed:', error);
-      haptic.error();
-    }
-  };
 
   return (
     <div className="min-h-screen max-h-screen bg-background flex flex-col ios-safe-layout mobile-content overflow-hidden">

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,21 @@
   "framework": "nextjs",
   "buildCommand": "npm run build:vercel",
   "installCommand": "npm ci",
+  "github": {
+    "silent": true
+  },
   "env": {
     "NEXT_TELEMETRY_DISABLED": "1"
-  }
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation

- Prepare the app for Vercel-first production deployment while reducing runtime JS and head bloat.  
- Improve perceived performance and render efficiency by trimming initial bundle, memoizing derived values, and stabilizing handlers.  
- Harden runtime headers and caching for static assets and service worker requests.  

### Description

- Tuned `next.config.js` to enable `reactStrictMode`, `compress`, modern image formats (`avif`, `webp`), console removal in production, `experimental.optimizePackageImports`, tightened `connect-src` in CSP, and added immutable static-asset and SW revalidation cache headers.  
- Simplified `src/app/layout.tsx` by switching to typed `Metadata`/`Viewport`, sourcing canonical URL from `NEXT_PUBLIC_APP_URL`, and removing duplicated head/security tags to reduce head payload.  
- Improved `src/app/page.tsx` by lazy-loading `AuthModal` with `next/dynamic`, memoizing computed stats with `useMemo`, stabilizing handlers with `useCallback`, and relocating the initial-loading early return to preserve hook order.  
- Hardened Vercel config in `vercel.json` with silent GitHub integration and an HSTS header, and updated docs/README with a Vercel deployment guide at `docs/vercel-deployment.md`.  

### Testing

- Ran `npm run lint` which completed successfully with one pre-existing non-blocking ESLint warning in `src/components/TamagotchiBlob.tsx`.  
- Ran `npm run type-check` (`tsc --noEmit`) which succeeded with no type errors.  
- Ran `npm run build:vercel` (`next build`) which produced a successful production build and static page generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dace3f13788325b7a1baefa18589af)