### PR TITLE
Improve README as portfolio case study

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,51 @@
 # Planter
 
-Planter is being rebuilt as a local-first botanical journal with an offline care companion.
+[![CI](https://github.com/michaelpreciado/Planter/actions/workflows/ci.yml/badge.svg)](https://github.com/michaelpreciado/Planter/actions/workflows/ci.yml)
 
-## What this version focuses on
+Planter is a local-first AI botanical journal for tracking plant records, progress photos, care notes, and offline-minded plant-care intelligence.
 
-- A warm botanical interface based on the visual prototype
-- Local-first plant records stored in the browser
-- Plant name, plant type, location, and care goals
-- Progress photo uploads for each plant
-- AI-style care feedback and follow-up questions grounded in local plant history
-- Important badges for plants that need attention
-- Health scoring from status, reminder cadence, notes, and photo history
-- Photo comparison for before/after progress review
-- Export/import backups so users own their local data
-- Settings for a future offline model such as Gemma 4 0.8B
+**Live demo:** https://planter-ekb2f1y8p-michael-preciados-projects.vercel.app  
+**Built by:** [Michael Preciado](https://github.com/michaelpreciado) / Preciado Tech
+
+## Why this project matters
+
+Planter is designed as a portfolio-grade product signal: a warm, mobile-first interface backed by practical state management, local data ownership, and AI-ready product thinking. It shows the kind of software I like to build — useful, polished, and grounded in real workflows instead of demo-only AI hype.
+
+## What it does
+
+- Stores local-first plant records in the browser
+- Tracks plant name, plant type, location, care goals, and status
+- Supports progress photo uploads for each plant
+- Generates AI-style care feedback grounded in local plant history
+- Highlights plants that need attention with badges and health scoring
+- Compares before/after photos for visible progress review
+- Supports export/import backups so users own their data
+- Includes settings for a future offline model such as Gemma 4 0.8B
+
+## Technical highlights
+
+- **Framework:** Next.js 14 + React 18 + TypeScript
+- **State/data:** Zustand-powered local-first plant state
+- **UI:** Tailwind CSS, responsive mobile-first layout, botanical visual system
+- **Deployment:** Vercel production build with Analytics and Speed Insights
+- **Quality gates:** GitHub Actions CI, TypeScript checks, production build validation
+
+## Product case study
+
+### Problem
+
+Plant care often gets scattered across memory, camera rolls, notes apps, and generic reminder tools. That makes it hard to see progress, remember care history, or understand what changed over time.
+
+### Approach
+
+Planter treats each plant like a small living project: profile, notes, status, photos, care history, and eventually local AI guidance. The rebuild intentionally removed legacy auth, sync, and mobile-shell complexity so the core experience could become clean, fast, and easy to reason about.
+
+### What this demonstrates
+
+- Product judgment: reducing scope to the version that actually matters
+- Frontend execution: responsive, polished UI that feels app-like
+- AI taste: care guidance framed as useful support, not gimmickry
+- Systems thinking: data ownership, backups, local-first direction, and maintainable architecture
 
 ## Run locally
 
@@ -28,6 +60,14 @@ npm run dev
 npm run type-check
 npm run build
 ```
+
+## Roadmap
+
+- Add screenshot/GIF demo above the fold
+- Add richer plant timeline and note filtering
+- Add offline model experiment for local care suggestions
+- Improve accessibility and keyboard navigation
+- Explore optional sync without sacrificing local-first ownership
 
 ## Direction
 


### PR DESCRIPTION
## Summary\n- reframes Planter README as a hiring/portfolio case study\n- adds CI badge, live demo, technical highlights, product case study, and roadmap\n- clarifies why the local-first rebuild matters as a product and engineering signal\n\n## Checks\n- npm run type-check\n- npm run build